### PR TITLE
Fix drag-handle description

### DIFF
--- a/docs/examples/drag-handle.mdx
+++ b/docs/examples/drag-handle.mdx
@@ -6,6 +6,6 @@ hide_table_of_contents: true
 
 import CodeViewer from '/src/components/CodeViewer';
 
-This example shows how the current zoom level can be used by a node to decide which content is visible.
+This example shows how to modify the area that allows a node to be dragged.
 
 <CodeViewer codePath="example-flows/DragHandle" additionalFiles={['DragHandleNode.js']} />


### PR DESCRIPTION
The Drag Handle description seems to be identical to the Contextual Zoom description, thus, not providing users with any insight into the example.